### PR TITLE
feat(cli): add --help and --version flags

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
 import { log } from './utils/logger.js';
 
 export interface ParsedCommand {
@@ -6,7 +9,12 @@ export interface ParsedCommand {
 }
 
 export function parseArgs(args: string[]): ParsedCommand {
-  if (args.length === 0) return { command: 'help', args: [] };
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    return { command: 'help', args: [] };
+  }
+  if (args.includes('--version') || args.includes('-v')) {
+    return { command: 'version', args: [] };
+  }
 
   const [first, second, ...rest] = args;
 
@@ -54,6 +62,12 @@ async function main() {
     case 'config-show': {
       const { runConfigShow } = await import('./commands/config-show.js');
       await runConfigShow(args);
+      break;
+    }
+    case 'version': {
+      const __dirname = dirname(fileURLToPath(import.meta.url));
+      const pkg = JSON.parse(readFileSync(resolve(__dirname, '..', 'package.json'), 'utf-8'));
+      console.log(`konbini v${pkg.version}`);
       break;
     }
     default:

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -21,4 +21,20 @@ describe('parseArgs', () => {
   it('returns help for no args', () => {
     expect(parseArgs([])).toEqual({ command: 'help', args: [] });
   });
+
+  it('returns help for --help flag', () => {
+    expect(parseArgs(['--help'])).toEqual({ command: 'help', args: [] });
+  });
+
+  it('returns help for -h flag', () => {
+    expect(parseArgs(['-h'])).toEqual({ command: 'help', args: [] });
+  });
+
+  it('returns version for --version flag', () => {
+    expect(parseArgs(['--version'])).toEqual({ command: 'version', args: [] });
+  });
+
+  it('returns version for -v flag', () => {
+    expect(parseArgs(['-v'])).toEqual({ command: 'version', args: [] });
+  });
 });


### PR DESCRIPTION
## Summary
- `--help` / `-h` フラグでヘルプ表示に対応
- `--version` / `-v` フラグでバージョン表示に対応（`konbini v0.2.4` 形式）
- テスト4件追加、全テストパス済み

## Test plan
- [x] `npx konbini --help` でヘルプが表示される
- [x] `npx konbini -h` でヘルプが表示される
- [x] `npx konbini --version` でバージョンが表示される
- [x] `npx konbini -v` でバージョンが表示される
- [x] 既存コマンド（init, update等）に影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)