### PR TITLE
feat: add worktree creation as step 0 in SDD workflow

### DIFF
--- a/templates/claude-md/en.md
+++ b/templates/claude-md/en.md
@@ -5,6 +5,7 @@ This project uses **konbini** (v{{VERSION}}) for Spec-Driven Development (SDD).
 When you receive a request for a new feature, improvement, or bug fix, **you must NOT write code directly**.
 Always follow the SDD workflow below:
 
+0. **Create a worktree** — If you are on the main branch, first create a `git worktree` for the feature branch. Skip if already in a worktree.
 1. `/kiro:spec-init <feature>` — Initialize the spec
 2. `/kiro:spec-requirements <feature>` — Generate requirements
 3. `/kiro:spec-design <feature>` — Create technical design

--- a/templates/claude-md/ja.md
+++ b/templates/claude-md/ja.md
@@ -5,6 +5,7 @@
 機能追加・改善・バグ修正の依頼を受けたとき、**直接コードを書いてはなりません**。
 必ず以下のSDDワークフローに従ってください:
 
+0. **worktree を作成** — mainブランチにいる場合、まず `git worktree` で作業ブランチを作成する。既にworktreeにいる場合はスキップ。
 1. `/kiro:spec-init <feature>` — specを初期化
 2. `/kiro:spec-requirements <feature>` — 要件を生成
 3. `/kiro:spec-design <feature>` — 技術設計を作成

--- a/templates/commands/spec-init.md
+++ b/templates/commands/spec-init.md
@@ -10,6 +10,8 @@ Initialize a new feature specification directory and generate initial requiremen
 
 ## Instructions
 
+0. **Worktree guard** — Before anything else, check if you are working in a git worktree (not on the main/master branch). If you are on the main branch, **stop and create a worktree first** using the `superpowers:using-git-worktrees` skill or `git worktree add`. Do NOT proceed with spec initialization until you are in an isolated worktree.
+
 1. **Read product context** from `.ao/steering/product.md` if it exists. Use this to understand the product vision, target users, and strategic goals.
 
 2. **Create the spec directory** at `.kiro/specs/$FEATURE_NAME/`.


### PR DESCRIPTION
## Summary
- SDDワークフローにステップ0「worktree作成」を追加（ja/enテンプレート）
- `/kiro:spec-init` にworktreeガードを追加（mainブランチなら停止）
- 二重防御でworktree分離を構造的に強制

## Test plan
- [ ] `konbini init` 後のCLAUDE.mdにステップ0が含まれることを確認
- [ ] mainブランチで `/kiro:spec-init` を実行し、worktree作成が先に求められることを確認
- [ ] 既にworktreeにいる場合はステップ0がスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)