### PR TITLE
refactor: slim CLAUDE.md template to pointer-only, add worktree guard

### DIFF
--- a/templates/claude-md/en.md
+++ b/templates/claude-md/en.md
@@ -3,28 +3,6 @@
 This project uses **konbini** (v{{VERSION}}) for Spec-Driven Development (SDD).
 
 When you receive a request for a new feature, improvement, or bug fix, **you must NOT write code directly**.
-Always follow the SDD workflow below:
-
-0. **Create a worktree** — If you are on the main branch, first create a `git worktree` for the feature branch. Skip if already in a worktree.
-1. `/kiro:spec-init <feature>` — Initialize the spec
-2. `/kiro:spec-requirements <feature>` — Generate requirements
-3. `/kiro:spec-design <feature>` — Create technical design
-4. `/kiro:spec-tasks <feature>` — Generate implementation tasks
-5. `/kiro:spec-impl <feature>` or `/kiro:ao-run <feature>` — Start implementation
+Always start with `/kiro:spec-init <feature>`. Each command will guide you to the next step.
 
 **Exception**: You may skip this workflow ONLY when the user explicitly instructs you to do so (e.g., "just do it", "skip SDD", "implement directly").
-
-## Autonomy Rules
-
-Follow the user's instructions precisely, and within that scope act autonomously: gather the necessary context and complete the requested work end-to-end in this run, asking questions only when essential information is missing or the instructions are critically ambiguous.
-
-- Do NOT ask for confirmation at each step. Once the user has approved the spec (requirements → design → tasks), proceed through implementation, commit, and PR creation without stopping.
-- The autonomy level (whether to stop at PR or auto-merge) is configured in `.ao/ao.yaml`. Follow the preset settings.
-- Ask questions only when there is genuine ambiguity that would lead to incorrect results if you guessed.
-
-## konbini Essentials
-
-- **Worktree isolation**: Use git worktrees for feature work. Never commit directly to the main branch.
-- **TDD**: Write failing tests before implementation code.
-- **Spec status**: Run `/kiro:spec-status <feature>` to check progress at any time.
-- **Validation**: Use `/kiro:validate-design <feature>`, `/kiro:validate-impl <feature>`, `/kiro:validate-gap <feature>` to verify work.

--- a/templates/claude-md/ja.md
+++ b/templates/claude-md/ja.md
@@ -3,28 +3,6 @@
 このプロジェクトは **konbini** (v{{VERSION}}) による仕様駆動開発 (SDD) を採用しています。
 
 機能追加・改善・バグ修正の依頼を受けたとき、**直接コードを書いてはなりません**。
-必ず以下のSDDワークフローに従ってください:
-
-0. **worktree を作成** — mainブランチにいる場合、まず `git worktree` で作業ブランチを作成する。既にworktreeにいる場合はスキップ。
-1. `/kiro:spec-init <feature>` — specを初期化
-2. `/kiro:spec-requirements <feature>` — 要件を生成
-3. `/kiro:spec-design <feature>` — 技術設計を作成
-4. `/kiro:spec-tasks <feature>` — 実装タスクを生成
-5. `/kiro:spec-impl <feature>` または `/kiro:ao-run <feature>` — 実装を開始
+必ず `/kiro:spec-init <feature>` から開始してください。各コマンドが次のステップを案内します。
 
 **例外**: ユーザーが明示的にスキップを指示した場合のみ省略可（例:「直接やって」「SDDスキップ」「そのまま実装して」）。
-
-## 自律行動ルール
-
-ユーザーの指示に忠実に従い、そのスコープ内で自律的に行動すること。必要なコンテキストを収集し、依頼された作業をこのセッション内で最後まで完遂する。質問は、不可欠な情報が欠けている場合や、指示が致命的に曖昧な場合のみ行う。
-
-- 各ステップで確認を求めてはならない。ユーザーがspec（要件→設計→タスク）を承認したら、実装・コミット・PR作成まで止まらずに進める。
-- 自律レベル（PRで止めるか自動マージするか）は `.ao/ao.yaml` で設定されている。プリセット設定に従うこと。
-- 質問するのは、推測すると誤った結果になる本当の曖昧さがある場合のみ。
-
-## konbini 必須事項
-
-- **worktree 分離**: 機能開発には git worktree を使用する。メインブランチに直接コミットしない。
-- **TDD**: 実装コードの前にテストを書く。
-- **spec 確認**: `/kiro:spec-status <feature>` でいつでも進捗を確認できる。
-- **検証**: `/kiro:validate-design <feature>`、`/kiro:validate-impl <feature>`、`/kiro:validate-gap <feature>` で成果物を検証する。


### PR DESCRIPTION
## Summary
- CLAUDE.md テンプレートをエントリーポイント（`/kiro:spec-init`）へのポインタのみにスリム化
- 詳細ルール（自律行動、worktree、TDD、検証）はコマンド側が既に持っているため CLAUDE.md から削除
- `spec-init.md` にworktreeガードを追加（mainブランチなら停止）
- ルール変更時にCLAUDE.mdの再注入が不要に

## Motivation
CLAUDE.md にルールを詳細に書くのはアンチパターン。ルール変更のたびに再注入が必要になる。
コマンドチェーン（spec-init → requirements → design → tasks → impl/ao-run）が各ステップの
ルールを内包しているので、CLAUDE.md はフローの入口を指すだけで十分。

## Test plan
- [ ] `konbini init` 後の CLAUDE.md がスリムなポインタのみであること
- [ ] mainブランチで `/kiro:spec-init` → worktree 作成が先に求められること
- [ ] コマンドチェーンが正しく次ステップを案内すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)